### PR TITLE
make the package compatible with current version of quanteda

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,10 @@
 Package: wordshoal
-Version: 0.1
+Version: 0.1.1
 Title: quanteda textmodel extensions for the wordshoal textmodel
 Description: Extends quanteda to provide an implementation of the Lauderdale and Herzog (2016) "wordshoal" model.
 Authors@R: c( person("Benjamin", "Lauderdale", email = "B.E.lauderdale@lse.ac.uk", role = c("aut")),
-    person("Kenneth", "Benoit", email = "kbenoit@lse.ac.uk", role = c("ctb", "cre")) )
+    person("Kenneth", "Benoit", email = "kbenoit@lse.ac.uk", role = c("ctb", "cre")),
+    person("Akitaka", "Matsuo", email = "a.matsuo@lse.ac.uk", role = c("ctb")))
 Maintainer: Benjamin Lauderdale <B.E.lauderdale@lse.ac.uk>
 License: GPL-3
 Depends:

--- a/R/textmodel_wordshoal.R
+++ b/R/textmodel_wordshoal.R
@@ -237,11 +237,11 @@ print.textmodel_wordshoal_fitted <- function(x, ...) {
     print(results,...)
 }
 
-setMethod("show", signature(object = "textmodel_wordshoal_fitted"), 
-          function(object) print(object))
-
-setMethod("show", signature(object = "textmodel_wordshoal_predicted"), 
-          function(object) print(object))
+# setMethod("show", signature(object = "textmodel_wordshoal_fitted"), 
+#           function(object) print(object))
+# 
+# setMethod("show", signature(object = "textmodel_wordshoal_predicted"), 
+#           function(object) print(object))
 
 
 #' Summarize a fitted textmodel_wordshoal object.

--- a/R/textmodel_wordshoal.R
+++ b/R/textmodel_wordshoal.R
@@ -12,14 +12,23 @@ setClass("textmodel_wordshoal_fitted",
                    groups = "factor",
                    authors = "factor",
                    ll = "numeric",
-                   se.theta = "numeric"),
-         contains = "textmodel_fitted")
+                   se.theta = "numeric",
+                   priors = "numeric", 
+                   phi = "numeric",
+                   docs = "character",
+                   features = "character",
+                   sigma = "numeric",
+                   x = "dfm", 
+                   y = "ANY", 
+                   call = "call", 
+                   dispersion = "character",
+                   method = "character"))
 
 setClass("textmodel_wordshoal_predicted",
          slots = c(newdata = "dfm", level = "numeric",
                    predvals = "data.frame"),
          prototype = list(level = 0.95),
-         contains = "textmodel_wordfish_fitted")
+         contains = "textmodel_wordshoal_fitted")
 
 # textmodel_wordshoal -----------
 
@@ -93,7 +102,7 @@ textmodel_wordshoal.dfm <- function(x, groups, authors, dir = c(1,2), tol = 1e-3
     # if (length(not_enough_rows <- which(lengths(split(docnames(x), authors)) < 2)))
     #     stop("only a single case for the following authors: \n", 
     #          paste(levels(authors)[not_enough_rows], collapse = "\n"))
-
+    
     S <- ndoc(x)
     psi <- rep(NA, S)
     
@@ -117,8 +126,8 @@ textmodel_wordshoal.dfm <- function(x, groups, authors, dir = c(1,2), tol = 1e-3
         wfresult <- textmodel_wordfish(groupdfm, tol = c(tol, 1e-8))
         
         # Save the results
-        # psi[groups == levels(groups)[j]] <- wfresult$theta
-        psi[groups == levels(groups)[j]] <- wfresult@theta
+        psi[groups == levels(groups)[j]] <- 
+            if(isS4(wfresult)){ wfresult@theta } else { wfresult$theta }
         
         if (j %% 20 == 0) 
             cat(j, " ", sep="") 
@@ -219,7 +228,6 @@ textmodel_wordshoal.dfm <- function(x, groups, authors, dir = c(1,2), tol = 1e-3
     ## Return results 
     
     cat("\nElapsed time:", (proc.time() - startTime)[3], "seconds.\n")
-    
     new("textmodel_wordshoal_fitted", 
         tol = tol,
         authors = authors,

--- a/R/textmodel_wordshoal.R
+++ b/R/textmodel_wordshoal.R
@@ -1,35 +1,3 @@
-# class definitions -------------
-
-#' @import quanteda
-#' @importFrom methods new
-setClass("textmodel_wordshoal_fitted",
-         slots = c(tol = "numeric",
-                   dir = "numeric",
-                   theta = "numeric",
-                   beta = "numeric",
-                   alpha = "numeric",
-                   psi = "numeric",
-                   groups = "factor",
-                   authors = "factor",
-                   ll = "numeric",
-                   se.theta = "numeric",
-                   priors = "numeric", 
-                   phi = "numeric",
-                   docs = "character",
-                   features = "character",
-                   sigma = "numeric",
-                   x = "dfm", 
-                   y = "ANY", 
-                   call = "call", 
-                   dispersion = "character",
-                   method = "character"))
-
-setClass("textmodel_wordshoal_predicted",
-         slots = c(newdata = "dfm", level = "numeric",
-                   predvals = "data.frame"),
-         prototype = list(level = 0.95),
-         contains = "textmodel_wordshoal_fitted")
-
 # textmodel_wordshoal -----------
 
 #' Wordshoal text model
@@ -228,7 +196,8 @@ textmodel_wordshoal.dfm <- function(x, groups, authors, dir = c(1,2), tol = 1e-3
     ## Return results 
     
     cat("\nElapsed time:", (proc.time() - startTime)[3], "seconds.\n")
-    new("textmodel_wordshoal_fitted", 
+    
+    result <- list(
         tol = tol,
         authors = authors,
         groups = groups,
@@ -237,7 +206,12 @@ textmodel_wordshoal.dfm <- function(x, groups, authors, dir = c(1,2), tol = 1e-3
         alpha = alpha,
         psi = psi,
         se.theta = thetaSE,
-        call = match.call())
+        call = match.call()
+    )
+    
+    class(result) <- c("textmodel_wordshoal_fitted", "textmodel", "list")
+    result
+    
 }
 
 
@@ -253,13 +227,13 @@ textmodel_wordshoal.dfm <- function(x, groups, authors, dir = c(1,2), tol = 1e-3
 print.textmodel_wordshoal_fitted <- function(x, ...) {
     cat("Fitted wordshoal model:\n")
     cat("Call:\n\t")
-    print(x@call)
+    print(x$call)
     cat("\nEstimated author positions:\n\n")
-    results <- data.frame(theta = x@theta,
-                          SE = x@se.theta,
-                          lower = x@theta - 1.96*x@se.theta,
-                          upper = x@theta + 1.96*x@se.theta)
-    rownames(results) <- levels(x@authors)
+    results <- data.frame(theta = x$theta,
+                          SE = x$se.theta,
+                          lower = x$theta - 1.96*x$se.theta,
+                          upper = x$theta + 1.96*x$se.theta)
+    rownames(results) <- levels(x$authors)
     print(results,...)
 }
 
@@ -279,15 +253,15 @@ setMethod("show", signature(object = "textmodel_wordshoal_predicted"),
 #' @method summary textmodel_wordshoal_fitted
 summary.textmodel_wordshoal_fitted <- function(object, ...) {
     cat("Call:\n\t")
-    print(object@call)
+    print(object$call)
     
     cat("\nEstimated document positions:\n")
-    results <- data.frame(theta = object@theta,
-                          SE = object@se.theta,
-                          lower = object@theta - 1.96*object@se.theta,
-                          upper = object@theta + 1.96*object@se.theta)
+    results <- data.frame(theta = object$theta,
+                          SE = object$se.theta,
+                          lower = object$theta - 1.96*object$se.theta,
+                          upper = object$theta + 1.96*object$se.theta)
     
-    rownames(results) <- levels(object@authors)
+    rownames(results) <- levels(object$authors)
     print(results, ...)
     invisible(results)
 }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ This package was [moved from
 **quanteda**](https://github.com/kbenoit/quanteda/pull/1172) on
 2017-12-27.
 
-**Maintainer:** [Benjamin Lauderdale](B.E.lauderdale@lse.ac.uk)
+**Maintainer:** [Benjamin Lauderdale](B.E.lauderdale@lse.ac.uk), 
+[Akitaka Matsuo](a.matsuo@lse.ac.uk)
 
 ## How to Install
 


### PR DESCRIPTION
Because of the change of the class of `textmodel_fitted_*` in `quanteda`, package `wordshoal` is not compatible with the current version of `quanteda`. This PR provides a quick fix to this issue. 

In particular, 

1. Make `textmodel_fitted_wordshoal`-class independent from `textmodel_fitted`.
2. Check the class of `wordfish`-output (S4 or not) and change the method of access.

